### PR TITLE
fix useless ctor rule, allow non null assertions

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,10 @@ module.exports = {
                 // note you must disable the base rule as it can report incorrect errors
                 "no-shadow": "off",
                 // This rule extends the base eslint/no-shadow rule. It adds support for TypeScript's this parameters and global augmentation, and adds options for TypeScript features
-                "@typescript-eslint/no-shadow": ["error"]
+                "@typescript-eslint/no-shadow": ["error"],
+                "@typescript-eslint/no-non-null-assertion": "off",
+                "no-useless-constructor": "off",
+                "@typescript-eslint/no-useless-constructor": "error"
             }
         }
     ]


### PR DESCRIPTION
Disables JS `no-useless-constructor` rule in favour of TS version which allows empty ctors that also define properties. 

Also allows using `non-null-assertions` (`!` suffix). If we had full TS codebases everywhere and we were all advanced TS users, it might be good to have that enabled, but with current state of things, this would only slow down TS adoption. In many cases it requires refactoring to get around this (or type casting), the rule itself feels quite strict (e.g. too strict for my personal projects :P).