### PR TITLE
fix: disable the `import/extensions` rule in JS and in TS

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ module.exports = {
                 "react/prop-types": "off",
                 // note you must disable the base rule as it can report incorrect errors
                 "no-unused-vars": "off",
+                // TypeScript doesn't support imports with `.ts` extensions, and `.js` makes the rule complain
+                "import/extensions": "off",
                 // This rule extends the base eslint/no-unused-vars rule. It adds support for TypeScript features, such as types.
                 "@typescript-eslint/no-unused-vars": ["error"],
                 // Allow semicolons at the end of the code block

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/eslint-config-ts",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Typescript ESLint configuration shared across projects in Apify.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Overrides take precedence, so while the rule is now disabled in JS, it wasn't in TS