### PR TITLE
feat: add  'consistent-type-imports'

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = {
                     }
                 ],
                 "@typescript-eslint/promise-function-async": "error",
+                "@typescript-eslint/consistent-type-imports": "error",
             }
         }
     ]


### PR DESCRIPTION
We like to use `import type` to add clarity. Any objections?